### PR TITLE
feat: make LinkedIn follows mandatory in onboarding

### DIFF
--- a/src/components/Onboarding/LinkedInFollow.tsx
+++ b/src/components/Onboarding/LinkedInFollow.tsx
@@ -193,6 +193,27 @@ export const LinkedInFollow = ({ userName, onComplete }: LinkedInFollowProps) =>
           </ul>
         </div>
 
+        {/* Progress indicator */}
+        <div className="bg-stone-50 rounded-lg p-4 mb-6">
+          <div className="flex items-center justify-between mb-2">
+            <h4 className="font-semibold text-stone-900">Follow Progress</h4>
+            <span className="text-sm text-stone-600">
+              {followedP2E && followedFounder ? '2/2 Complete' : `${(followedP2E ? 1 : 0) + (followedFounder ? 1 : 0)}/2 Complete`}
+            </span>
+          </div>
+          <div className="w-full bg-stone-200 rounded-full h-2">
+            <div 
+              className="bg-violet-600 h-2 rounded-full transition-all duration-300"
+              style={{ width: `${((followedP2E ? 1 : 0) + (followedFounder ? 1 : 0)) * 50}%` }}
+            ></div>
+          </div>
+          {!(followedP2E && followedFounder) && (
+            <p className="text-sm text-stone-600 mt-2">
+              Please follow both P2E and Sebastien on LinkedIn to continue
+            </p>
+          )}
+        </div>
+
         {/* Action buttons */}
         <div className="flex flex-col sm:flex-row gap-3">
           <button
@@ -207,9 +228,14 @@ export const LinkedInFollow = ({ userName, onComplete }: LinkedInFollowProps) =>
               }
               onComplete();
             }}
-            className="flex-1 bg-violet-600 hover:bg-violet-700 text-white font-medium py-3 px-6 rounded-lg transition-colors"
+            disabled={!followedP2E || !followedFounder}
+            className={`flex-1 font-medium py-3 px-6 rounded-lg transition-colors ${
+              followedP2E && followedFounder
+                ? 'bg-violet-600 hover:bg-violet-700 text-white cursor-pointer'
+                : 'bg-stone-300 text-stone-500 cursor-not-allowed'
+            }`}
           >
-            Continue to Dashboard
+            {followedP2E && followedFounder ? 'Continue to Dashboard' : 'Complete LinkedIn Follows to Continue'}
           </button>
         </div>
 


### PR DESCRIPTION
### **User description**
- Add progress indicator showing follow completion status
- Disable continue button until both P2E and Sebastien are followed
- Add clear messaging about requirements
- Update button text and styling based on completion state
- Maintain glassmorphism design consistency


___

### **PR Type**
Enhancement


___

### **Description**
- Add progress indicator showing follow completion status

- Make LinkedIn follows mandatory before continuing onboarding

- Update button styling and text based on completion state

- Add clear messaging about follow requirements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User enters LinkedIn Follow step"] --> B["Progress indicator shows 0/2 complete"]
  B --> C["User follows P2E and Sebastien"]
  C --> D["Progress bar updates to 2/2 complete"]
  D --> E["Continue button becomes enabled"]
  E --> F["User can proceed to dashboard"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LinkedInFollow.tsx</strong><dd><code>Add mandatory LinkedIn follow progress tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/Onboarding/LinkedInFollow.tsx

<ul><li>Add progress indicator with completion counter and progress bar<br> <li> Disable continue button until both LinkedIn follows are completed<br> <li> Update button text and styling based on follow completion state<br> <li> Add instructional messaging for incomplete follows</ul>


</details>


  </td>
  <td><a href="https://github.com/Propel-2-Excel/point-system-frontend/pull/21/files#diff-a1c0f2057e916943806fed5be367970efba9a235a6f501eca25203fb90d1cb73">+28/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

